### PR TITLE
fix sub-list examples

### DIFF
--- a/_posts/2025-04-28-distill-example.md
+++ b/_posts/2025-04-28-distill-example.md
@@ -356,16 +356,16 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 1. First ordered list item
 2. Another item
-⋅⋅* Unordered sub-list. 
+  * Unordered sub-list.
 1. Actual numbers don't matter, just that it's a number
-⋅⋅1. Ordered sub-list
+   1. Ordered sub-list
 4. And another item.
 
-⋅⋅⋅You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).
+   You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).
 
-⋅⋅⋅To have a line break without a paragraph, you will need to use two trailing spaces.⋅⋅
-⋅⋅⋅Note that this line is separate, but within the same paragraph.⋅⋅
-⋅⋅⋅(This is contrary to the typical GFM line break behavior, where trailing spaces are not required.)
+   To have a line break without a paragraph, you will need to use two trailing spaces.
+   Note that this line is separate, but within the same paragraph.
+   (This is contrary to the typical GFM line break behavior, where trailing spaces are not required.)
 
 * Unordered lists can use asterisks
 - Or minuses


### PR DESCRIPTION
This PR fixes the sub-list examples. This is what is rendered locally before:

<img width="722" alt="Screenshot 2024-11-06 at 7 38 37 PM" src="https://github.com/user-attachments/assets/1db004f9-c7a8-49d8-b51d-c9b92635da7a">

This is what is rendered after:

<img width="704" alt="Screenshot 2024-11-06 at 7 46 30 PM" src="https://github.com/user-attachments/assets/81a7dc6d-0689-4e6f-99e7-e17483304a21">

It seems that '⋅' character somehow slipped in instead of actual space. Also, apparently ordered sub-list needs at least 3-space indent.